### PR TITLE
Add fullscreen toggle to options

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -115,6 +115,11 @@ restart={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":5,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
+toggle_fullscreen={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777254,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [layer_names]
 

--- a/project.godot
+++ b/project.godot
@@ -38,7 +38,7 @@ _global_script_class_icons={
 
 [application]
 
-config/name="gmtk-2022"
+config/name="Unweighted"
 run/main_scene="res://src/states/Menu.tscn"
 config/icon="res://icon.png"
 

--- a/src/scripts/Global.gd
+++ b/src/scripts/Global.gd
@@ -90,16 +90,23 @@ func _ready() -> void:
 	load_config()
 	audio_stream = AudioStreamPlayer.new()
 	audio_stream.stream = BG_MUSIC
-	audio_stream.pause_mode = Node.PAUSE_MODE_PROCESS
 	update_volumes()
 	audio_stream.play()
 	add_child(audio_stream)
+	pause_mode = Node.PAUSE_MODE_PROCESS
 
 
 func _notification(what: int) -> void:
 	if what == MainLoop.NOTIFICATION_WM_QUIT_REQUEST:
 		save_config()
 		get_tree().quit()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("toggle_fullscreen"):
+		OS.window_fullscreen = not OS.window_fullscreen
+		save_config()
+		get_tree().set_input_as_handled()
 
 
 func update_volumes() -> void:
@@ -167,6 +174,11 @@ func load_config() -> void:
 			elif animation_speed > 4:
 				animation_speed = 4
 
+	if "window_fullscreen" in config:
+		var new_fullscreen = config["window_fullscreen"]
+		if typeof(new_fullscreen) == TYPE_BOOL:
+			OS.window_fullscreen = new_fullscreen
+
 	if OS.get_name() != "HTML5":
 		if "autosplitter_enabled" in config:
 			var new_autosplitter_enabled = config["autosplitter_enabled"]
@@ -188,6 +200,7 @@ func save_config() -> void:
 		"sound_volume": sound_volume,
 		"music_volume": music_volume,
 		"animation_speed": animation_speed,
+		"window_fullscreen": OS.window_fullscreen,
 	}
 
 	if OS.get_name() != "HTML5":

--- a/src/states/OptionsMenu.gd
+++ b/src/states/OptionsMenu.gd
@@ -5,11 +5,17 @@ signal options_exited
 
 var animation_speed_strings := ["Slow", "Normal", "Fast", "Very Fast", "Hyperspeed"]
 
+onready var fullscreen_option_button: OptionButton = $C/V/G/FullscreenOptionButton
+
 
 func _ready() -> void:
+	fullscreen_option_button.add_item("Windowed")
+	fullscreen_option_button.add_item("Fullscreen")
+
 	$C/V/G/SoundVolumeSlider.value = Global.sound_volume
 	$C/V/G/MusicVolumeSlider.value = Global.music_volume
 	$C/V/G/AnimationSpeedSlider.value = Global.animation_speed
+	fullscreen_option_button.select(1 if OS.window_fullscreen else 0)
 	if OS.get_name() == "HTML5":
 		$C/V/V.hide()
 	else:
@@ -17,11 +23,16 @@ func _ready() -> void:
 		$C/V/V/H/AutosplitterPortSpinBox.value = Global.autosplitter_port
 
 
+func _process(_delta: float) -> void:
+	if OS.window_fullscreen != (fullscreen_option_button.selected == 1):
+		fullscreen_option_button.select(1 if OS.window_fullscreen else 0)
+
+
 func _unhandled_input(event: InputEvent) -> void:
 	if not visible:
 		return
 	if event.is_action_pressed("ui_cancel"):
-		_on_BackButton_pressed()
+		close_menu()
 		get_tree().set_input_as_handled()
 
 
@@ -30,9 +41,10 @@ func show_menu() -> void:
 	$C/V/BackButton.grab_focus()
 
 
-func _on_BackButton_pressed() -> void:
+func close_menu() -> void:
 	hide()
 	emit_signal("options_exited")
+	Global.save_config()
 
 
 func _on_SoundVolumeSlider_value_changed(value: float) -> void:
@@ -48,6 +60,10 @@ func _on_MusicVolumeSlider_value_changed(value: float) -> void:
 func _on_AnimationSpeedSlider_value_changed(value: float) -> void:
 	Global.animation_speed = int(value)
 	$C/V/G/AnimationSpeedLabel.text = animation_speed_strings[value]
+
+
+func _on_FullscreenOptionsButton_item_selected(index: int) -> void:
+	OS.window_fullscreen = (index == 1)
 
 
 func _on_AutosplitterEnabledCheck_toggled(button_pressed: bool) -> void:

--- a/src/states/OptionsMenu.tscn
+++ b/src/states/OptionsMenu.tscn
@@ -19,9 +19,9 @@ anchor_bottom = 1.0
 
 [node name="V" type="VBoxContainer" parent="C"]
 margin_left = 125.0
-margin_top = 90.0
+margin_top = 76.0
 margin_right = 514.0
-margin_bottom = 389.0
+margin_bottom = 404.0
 custom_constants/separation = 30
 
 [node name="Title" type="Label" parent="C/V"]
@@ -34,7 +34,7 @@ align = 1
 [node name="G" type="GridContainer" parent="C/V"]
 margin_top = 86.0
 margin_right = 389.0
-margin_bottom = 151.0
+margin_bottom = 180.0
 custom_constants/hseparation = 25
 columns = 3
 
@@ -108,10 +108,29 @@ margin_bottom = 65.0
 rect_min_size = Vector2( 100, 0 )
 text = "Normal"
 
-[node name="V" type="VBoxContainer" parent="C/V"]
-margin_top = 181.0
+[node name="FullscreenLabel" type="Label" parent="C/V/G"]
+margin_top = 72.0
+margin_right = 139.0
+margin_bottom = 91.0
+text = "Windowed Mode"
+align = 2
+
+[node name="FullscreenOptionButton" type="OptionButton" parent="C/V/G"]
+margin_left = 164.0
+margin_top = 69.0
+margin_right = 264.0
+margin_bottom = 94.0
+
+[node name="FullscreenSpacer" type="Control" parent="C/V/G"]
+margin_left = 289.0
+margin_top = 69.0
 margin_right = 389.0
-margin_bottom = 244.0
+margin_bottom = 94.0
+
+[node name="V" type="VBoxContainer" parent="C/V"]
+margin_top = 210.0
+margin_right = 389.0
+margin_bottom = 273.0
 
 [node name="AutosplitterLabel" type="Label" parent="C/V/V"]
 margin_right = 389.0
@@ -155,9 +174,9 @@ value = 5678.0
 
 [node name="BackButton" type="Button" parent="C/V"]
 margin_left = 144.0
-margin_top = 274.0
+margin_top = 303.0
 margin_right = 244.0
-margin_bottom = 299.0
+margin_bottom = 328.0
 rect_min_size = Vector2( 100, 0 )
 size_flags_horizontal = 4
 text = "Back"
@@ -165,6 +184,7 @@ text = "Back"
 [connection signal="value_changed" from="C/V/G/SoundVolumeSlider" to="." method="_on_SoundVolumeSlider_value_changed"]
 [connection signal="value_changed" from="C/V/G/MusicVolumeSlider" to="." method="_on_MusicVolumeSlider_value_changed"]
 [connection signal="value_changed" from="C/V/G/AnimationSpeedSlider" to="." method="_on_AnimationSpeedSlider_value_changed"]
+[connection signal="item_selected" from="C/V/G/FullscreenOptionButton" to="." method="_on_FullscreenOptionsButton_item_selected"]
 [connection signal="toggled" from="C/V/V/H/AutosplitterEnabledCheck" to="." method="_on_AutosplitterEnabledCheck_toggled"]
 [connection signal="value_changed" from="C/V/V/H/AutosplitterPortSpinBox" to="." method="_on_AutosplitterPortSpinBox_value_changed"]
-[connection signal="pressed" from="C/V/BackButton" to="." method="_on_BackButton_pressed"]
+[connection signal="pressed" from="C/V/BackButton" to="." method="close_menu"]


### PR DESCRIPTION
Toggle with F11 key (I didn't do Alt+Enter since that conflicts with the enter key in menus... not sure if there's a good way to approach that)

This also changes the project name from "gmtk-2022" to "Unweighted" which is good for the window name and exporting. Note that will cause your save data to seem to reset (since it's now pointing to a different folder than it was before)