### PR TITLE
Fullscreen updates

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -117,7 +117,7 @@ restart={
 }
 toggle_fullscreen={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777254,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 view_hidden_x_neg={

--- a/src/scripts/Global.gd
+++ b/src/scripts/Global.gd
@@ -140,7 +140,7 @@ func _notification(what: int) -> void:
 		get_tree().quit()
 
 
-func _unhandled_input(event: InputEvent) -> void:
+func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("toggle_fullscreen"):
 		OS.window_fullscreen = not OS.window_fullscreen
 		save_config()

--- a/src/scripts/Global.gd
+++ b/src/scripts/Global.gd
@@ -142,6 +142,8 @@ func _notification(what: int) -> void:
 
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("toggle_fullscreen"):
+		if OS.get_name() == "HTML5":
+			return
 		OS.window_fullscreen = not OS.window_fullscreen
 		save_config()
 		get_tree().set_input_as_handled()


### PR DESCRIPTION
* Alt-Enter toggles fullscreen like everything else
    * I didn't do this before because I couldn't figure out how to do it without triggering menu buttons as well. Just handle it in `_input()` rather than `_unhandled_input()`
* No shortcut to toggle fullscreen in HTML5 since F11 should already do that